### PR TITLE
Implement bar ingestion in PriceBuffer and add tests

### DIFF
--- a/tests/test_price_buffer.py
+++ b/tests/test_price_buffer.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+# Ensure the project root is on the import path so ``utils`` can be resolved
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.PriceBuffer import PriceBuffer
+
+
+def _bar(ts, o=1, h=2, l=0, c=1):
+    return {"timestamp": ts, "open": o, "high": h, "low": l, "close": c}
+
+
+def test_update_from_bar_respects_max_size():
+    buf = PriceBuffer(maxBars=3)
+    bars = [
+        _bar("2024-01-01T00:00:00Z"),
+        _bar("2024-01-01T00:01:00Z"),
+        _bar("2024-01-01T00:02:00Z"),
+        _bar("2024-01-01T00:03:00Z"),
+    ]
+    for b in bars:
+        buf.updateFromBar(b)
+    stored = buf.getBars()
+    assert len(stored) == 3
+    assert stored[0]["timestamp"] == "2024-01-01T00:01:00Z"
+    assert stored[-1]["timestamp"] == "2024-01-01T00:03:00Z"
+
+
+def test_update_from_bar_ignores_invalid_input():
+    buf = PriceBuffer()
+    buf.updateFromBar({"open": 1})
+    assert buf.getBars() == []
+
+
+def test_timestamp_normalization():
+    buf = PriceBuffer()
+    buf.updateFromBar(_bar("2024-01-01T00:00:00"))  # missing trailing Z
+    stored = buf.getBars()
+    assert stored[0]["timestamp"].endswith("Z")

--- a/utils/PriceBuffer.py
+++ b/utils/PriceBuffer.py
@@ -1,6 +1,8 @@
 # utils/price_buffer.py
 from datetime import datetime
-from DataCleaner import DataCleaner
+
+# Use relative import so PriceBuffer can be imported as part of the utils package
+from .DataCleaner import DataCleaner
 
 class PriceBuffer:
     def __init__(self, maxBars=500):
@@ -31,6 +33,30 @@ class PriceBuffer:
             self.currentBar["high"] = max(self.currentBar["high"], price)
             self.currentBar["low"] = min(self.currentBar["low"], price)
             self.currentBar["close"] = price
+
+    def updateFromBar(self, bar):
+        """Directly append a completed OHLC bar to the buffer.
+
+        Parameters
+        ----------
+        bar : dict
+            A dictionary containing at least the keys
+            "timestamp", "open", "high", "low", and "close".
+        """
+        required = {"timestamp", "open", "high", "low", "close"}
+        if not isinstance(bar, dict) or not required.issubset(bar):
+            return
+
+        # Normalize timestamps (ensures trailing 'Z') and copy to avoid
+        # mutating the caller's dictionary.
+        bar = DataCleaner.normalizeTimestamp(dict(bar))
+
+        self.bars.append(bar)
+        if len(self.bars) > self.maxBars:
+            self.bars.pop(0)
+
+        # When bars are supplied directly we don't keep a "current" bar.
+        self.currentBar = None
 
     def getBars(self):
         allBars = self.bars + ([self.currentBar] if self.currentBar else [])


### PR DESCRIPTION
## Summary
- fix PriceBuffer import to DataCleaner
- support direct OHLC bar ingestion with new updateFromBar method
- add tests covering bar updates, invalid inputs, and timestamp normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897eb147ddc8326ae585257cda06a92